### PR TITLE
Update to .NET7

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 7.0
     - name: Install dependencies

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core
+    - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1
+        dotnet-version: 7.0
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/example/Algorithm.Examples.Tests/Algorithm.Examples.Tests.csproj
+++ b/example/Algorithm.Examples.Tests/Algorithm.Examples.Tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net7</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="nunit" Version="3.13.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="nunit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/example/Algorithm.Examples/Algorithm.Examples.csproj
+++ b/example/Algorithm.Examples/Algorithm.Examples.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net7</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/example/Algorithm.Examples/B.cs
+++ b/example/Algorithm.Examples/B.cs
@@ -11,7 +11,7 @@ namespace Algorithm.Examples
             var (N, Q) = (NQ[0], NQ[1]);
             var A = Console.ReadLine().Split(" ").Select(int.Parse).ToArray();
 
-            var ft = new FenwickTree(N);
+            var ft = new FenwickTree<long>(N);
             for (var i = 0; i < N; i++) ft.Add(i, A[i]);
 
             for (var i = 0; i < Q; i++)

--- a/src/Algorithm/Algorithm.csproj
+++ b/src/Algorithm/Algorithm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net7</TargetFramework>
     </PropertyGroup>
 
 </Project>

--- a/src/Algorithm/FenwickTree.cs
+++ b/src/Algorithm/FenwickTree.cs
@@ -1,21 +1,23 @@
 using System;
+using System.Numerics;
 
 namespace Algorithm
 {
-    public class FenwickTree
+    public class FenwickTree<T>
+        where T : struct, IAdditionOperators<T, T, T>, ISubtractionOperators<T, T, T>, IComparisonOperators<T, T, bool>
     {
         public int Length { get; }
 
-        private readonly long[] _data;
+        private readonly T[] _data;
 
         public FenwickTree(int length)
         {
             if (length < 0) throw new ArgumentOutOfRangeException(nameof(length));
             Length = length;
-            _data = new long[length];
+            _data = new T[length];
         }
 
-        public void Add(int index, long value)
+        public void Add(int index, T value)
         {
             if (index < 0 || Length <= index) throw new ArgumentOutOfRangeException(nameof(index));
             index++;
@@ -26,10 +28,10 @@ namespace Algorithm
             }
         }
 
-        public long Sum(int length)
+        public T Sum(int length)
         {
             if (length < 0 || Length < length) throw new ArgumentOutOfRangeException(nameof(length));
-            var s = 0L;
+            T s = default;
             while (length > 0)
             {
                 s += _data[length - 1];
@@ -39,17 +41,17 @@ namespace Algorithm
             return s;
         }
 
-        public long Sum(int left, int right)
+        public T Sum(int left, int right)
         {
             if (left < 0 || right < left || Length < right) throw new ArgumentOutOfRangeException();
             return Sum(right) - Sum(left);
         }
 
-        public int LowerBound(long value) => Bound(value, (x, y) => x <= y);
+        public int LowerBound(T value) => Bound(value, (x, y) => x <= y);
 
-        public int UpperBound(long value) => Bound(value, (x, y) => x < y);
+        public int UpperBound(T value) => Bound(value, (x, y) => x < y);
 
-        private int Bound(long value, Func<long, long, bool> compare)
+        private int Bound(T value, Func<T, T, bool> compare)
         {
             if (Length == 0 || compare(value, _data[0])) return 0;
             var x = 0;

--- a/src/Algorithm/FenwickTree2D.cs
+++ b/src/Algorithm/FenwickTree2D.cs
@@ -1,13 +1,15 @@
 using System;
+using System.Numerics;
 
 namespace Algorithm
 {
-    public class FenwickTree2D
+    public class FenwickTree2D<T>
+        where T : struct, IAdditionOperators<T, T, T>, ISubtractionOperators<T, T, T>
     {
         public int Height { get; }
         public int Width { get; }
 
-        private readonly long[] _data;
+        private readonly T[] _data;
 
         public FenwickTree2D(int height, int width)
         {
@@ -15,10 +17,10 @@ namespace Algorithm
             if (width < 0) throw new ArgumentOutOfRangeException(nameof(width));
             Height = height;
             Width = width;
-            _data = new long[Height * Width];
+            _data = new T[Height * Width];
         }
 
-        public void Add(int height, int width, long value)
+        public void Add(int height, int width, T value)
         {
             if (height < 0 || Height <= height) throw new ArgumentOutOfRangeException(nameof(height));
             if (width < 0 || Width <= width) throw new ArgumentOutOfRangeException(nameof(width));
@@ -31,11 +33,11 @@ namespace Algorithm
             }
         }
 
-        public long Sum(int height, int width)
+        public T Sum(int height, int width)
         {
             if (height < 0 || Height < height) throw new ArgumentOutOfRangeException(nameof(height));
             if (width < 0 || Width < width) throw new ArgumentOutOfRangeException(nameof(width));
-            var sum = 0L;
+            T sum = default;
             for (var i = height; i > 0; i -= i & -i)
             {
                 for (var j = width; j > 0; j -= j & -j)
@@ -47,7 +49,7 @@ namespace Algorithm
             return sum;
         }
 
-        public long Sum(int height1, int width1, int height2, int width2)
+        public T Sum(int height1, int width1, int height2, int width2)
         {
             if (height1 < 0 || Height < height1) throw new ArgumentOutOfRangeException(nameof(height1));
             if (width1 < 0 || Width < width1) throw new ArgumentOutOfRangeException(nameof(width1));

--- a/src/Algorithm/FlowGraph.cs
+++ b/src/Algorithm/FlowGraph.cs
@@ -225,27 +225,8 @@ namespace Algorithm
             return result.Reverse();
         }
 
-        public readonly struct Edge
-        {
-            public readonly int From;
-            public readonly int To;
-            public readonly long Capacity;
-            public readonly long Flow;
-            public readonly long Cost;
+        public readonly record struct Edge(int From, int To, long Capacity, long Flow, long Cost = 0);
 
-            public Edge(int from, int to, long capacity, long flow, long cost = 0) =>
-                (From, To, Capacity, Flow, Cost) = (from, to, capacity, flow, cost);
-        }
-
-        private readonly struct InternalEdge
-        {
-            public readonly int To;
-            public readonly int Rev;
-            public readonly long Capacity;
-            public readonly long Cost;
-
-            public InternalEdge(int to, int rev, long capacity, long cost) =>
-                (To, Rev, Capacity, Cost) = (to, rev, capacity, cost);
-        }
+        private readonly record struct InternalEdge(int To, int Rev, long Capacity, long Cost);
     }
 }

--- a/src/Algorithm/ModuloInteger.cs
+++ b/src/Algorithm/ModuloInteger.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Numerics;
 
 namespace Algorithm
 {
-    public readonly struct ModuloInteger : IEquatable<ModuloInteger>
+    public readonly struct ModuloInteger : IEquatable<ModuloInteger>,
+        IAdditionOperators<ModuloInteger, ModuloInteger, ModuloInteger>,
+        IDivisionOperators<ModuloInteger, ModuloInteger, ModuloInteger>,
+        IMultiplyOperators<ModuloInteger, ModuloInteger, ModuloInteger>,
+        ISubtractionOperators<ModuloInteger, ModuloInteger, ModuloInteger>,
+        IEqualityOperators<ModuloInteger, ModuloInteger, bool>
     {
         public long Value { get; }
         // The modulo will be used as an editable property.
@@ -24,14 +30,14 @@ namespace Algorithm
 
         public static implicit operator int(ModuloInteger mint) => (int)mint.Value;
         public static implicit operator long(ModuloInteger mint) => mint.Value;
-        public static implicit operator ModuloInteger(int value) => new ModuloInteger(value);
-        public static implicit operator ModuloInteger(long value) => new ModuloInteger(value);
-        public static ModuloInteger operator +(ModuloInteger a, ModuloInteger b) => a.Value + b.Value;
-        public static ModuloInteger operator -(ModuloInteger a, ModuloInteger b) => a.Value - b.Value;
-        public static ModuloInteger operator *(ModuloInteger a, ModuloInteger b) => a.Value * b.Value;
-        public static ModuloInteger operator /(ModuloInteger a, ModuloInteger b) => a * b.Inverse();
-        public static bool operator ==(ModuloInteger a, ModuloInteger b) => a.Equals(b);
-        public static bool operator !=(ModuloInteger a, ModuloInteger b) => !a.Equals(b);
+        public static implicit operator ModuloInteger(int value) => new(value);
+        public static implicit operator ModuloInteger(long value) => new(value);
+        public static ModuloInteger operator +(ModuloInteger left, ModuloInteger right) => left.Value + right.Value;
+        public static ModuloInteger operator -(ModuloInteger left, ModuloInteger right) => left.Value - right.Value;
+        public static ModuloInteger operator *(ModuloInteger left, ModuloInteger right) => left.Value * right.Value;
+        public static ModuloInteger operator /(ModuloInteger left, ModuloInteger right) => left * right.Inverse();
+        public static bool operator ==(ModuloInteger left, ModuloInteger right) => left.Equals(right);
+        public static bool operator !=(ModuloInteger left, ModuloInteger right) => !left.Equals(right);
         public bool Equals(ModuloInteger other) => Value == other.Value;
         public override bool Equals(object obj) => obj is ModuloInteger other && Equals(other);
         public override int GetHashCode() => Value.GetHashCode();

--- a/src/Algorithm/StronglyConnectedComponent.cs
+++ b/src/Algorithm/StronglyConnectedComponent.cs
@@ -95,11 +95,6 @@ namespace Algorithm
             return groups;
         }
 
-        private readonly struct Edge
-        {
-            public readonly int To;
-
-            public Edge(int to) => To = to;
-        }
+        private readonly record struct Edge(int To);
     }
 }

--- a/test/Algorithm.Tests/Algorithm.Tests.csproj
+++ b/test/Algorithm.Tests/Algorithm.Tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net7</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="nunit" Version="3.13.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="nunit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Algorithm.Tests/FenwickTree2DTests.cs
+++ b/test/Algorithm.Tests/FenwickTree2DTests.cs
@@ -8,16 +8,16 @@ namespace Algorithm.Tests
         [Test]
         public void InitializeTest()
         {
-            Assert.DoesNotThrow(() => _ = new FenwickTree2D(0, 0));
-            Assert.DoesNotThrow(() => _ = new FenwickTree2D(1, 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => _ = new FenwickTree2D(-1, 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => _ = new FenwickTree2D(0, -1));
+            Assert.DoesNotThrow(() => _ = new FenwickTree2D<long>(0, 0));
+            Assert.DoesNotThrow(() => _ = new FenwickTree2D<long>(1, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => _ = new FenwickTree2D<long>(-1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => _ = new FenwickTree2D<long>(0, -1));
 
-            var cum = new FenwickTree2D(0, 0);
+            var cum = new FenwickTree2D<long>(0, 0);
             Assert.That(cum.Height, Is.Zero);
             Assert.That(cum.Width, Is.Zero);
 
-            cum = new FenwickTree2D(1, 1);
+            cum = new FenwickTree2D<long>(1, 1);
             Assert.That(cum.Height, Is.EqualTo(1));
             Assert.That(cum.Width, Is.EqualTo(1));
         }
@@ -26,7 +26,7 @@ namespace Algorithm.Tests
         [TestCase(0, -1)]
         public void ArgumentOutOfRangeTest(int h, int w)
         {
-            var cum = new FenwickTree2D(1, 1);
+            var cum = new FenwickTree2D<long>(1, 1);
             Assert.Throws<ArgumentOutOfRangeException>(() => cum.Add(h, w, 1));
             Assert.Throws<ArgumentOutOfRangeException>(() => cum.Sum(h, w));
             Assert.Throws<ArgumentOutOfRangeException>(() => cum.Sum(h, w, 0, 0));
@@ -36,7 +36,7 @@ namespace Algorithm.Tests
         [Test]
         public void AddTest()
         {
-            var cum = new FenwickTree2D(1, 1);
+            var cum = new FenwickTree2D<long>(1, 1);
             const int expected = 1;
             cum.Add(0, 0, expected);
             var actual = cum.Sum(0, 0);
@@ -51,7 +51,7 @@ namespace Algorithm.Tests
         {
             const int height = 3;
             const int width = 3;
-            var cum = new FenwickTree2D(height, width);
+            var cum = new FenwickTree2D<long>(height, width);
             for (var i = 0; i < height; i++)
             {
                 for (var j = 0; j < width; j++)
@@ -77,7 +77,7 @@ namespace Algorithm.Tests
             var random = new Random(0);
             const int height = 50;
             const int width = 50;
-            var ft = new FenwickTree2D(height, width);
+            var ft = new FenwickTree2D<long>(height, width);
             var data = new long[height, width];
             for (var i = 0; i < height; i++)
             {

--- a/test/Algorithm.Tests/FenwickTreeTests.cs
+++ b/test/Algorithm.Tests/FenwickTreeTests.cs
@@ -8,15 +8,15 @@ namespace Algorithm.Tests
         [Test]
         public void InitializeTest()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => _ = new FenwickTree(-1));
-            Assert.That(new FenwickTree(0).Length, Is.Zero);
-            Assert.That(new FenwickTree(10).Length, Is.EqualTo(10));
+            Assert.Throws<ArgumentOutOfRangeException>(() => _ = new FenwickTree<long>(-1));
+            Assert.That(new FenwickTree<long>(0).Length, Is.Zero);
+            Assert.That(new FenwickTree<long>(10).Length, Is.EqualTo(10));
         }
 
         [Test]
         public void EmptyTest()
         {
-            var ft = new FenwickTree(0);
+            var ft = new FenwickTree<long>(0);
             Assert.That(ft.Sum(0), Is.Zero);
             Assert.That(ft.Sum(0, 0), Is.Zero);
         }
@@ -24,7 +24,7 @@ namespace Algorithm.Tests
         [Test]
         public void NativeTest([Range(0, 50)] int n)
         {
-            var ft = new FenwickTree(n);
+            var ft = new FenwickTree<long>(n);
             for (var i = 0; i < n; i++) ft.Add(i, i * i);
 
             for (var i = 0; i <= n; i++)
@@ -48,7 +48,7 @@ namespace Algorithm.Tests
         [Test]
         public void LowerBoundTest([Range(0, 50)] int n)
         {
-            var ft = new FenwickTree(n);
+            var ft = new FenwickTree<long>(n);
             for (var i = 0; i < n; i++) ft.Add(i, i * i);
             var sum = new int[n + 1];
             for (var i = 0; i < n; i++) sum[i + 1] = sum[i] + i * i;
@@ -62,7 +62,7 @@ namespace Algorithm.Tests
         [Test]
         public void UpperBoundTest([Range(0, 50)] int n)
         {
-            var ft = new FenwickTree(n);
+            var ft = new FenwickTree<long>(n);
             for (var i = 0; i < n; i++) ft.Add(i, i * i);
             var sum = new int[n + 1];
             for (var i = 0; i < n; i++) sum[i + 1] = sum[i] + i * i;
@@ -76,14 +76,14 @@ namespace Algorithm.Tests
         [Test]
         public void ArgumentOutOfRangeInAddTest([Values(-1, 10)] int i)
         {
-            var ft = new FenwickTree(10);
+            var ft = new FenwickTree<long>(10);
             Assert.Throws<ArgumentOutOfRangeException>(() => ft.Add(i, 0));
         }
 
         [Test]
         public void ArgumentOutOfRangeInSumTest1([Values(-1, 11)] int i)
         {
-            var ft = new FenwickTree(10);
+            var ft = new FenwickTree<long>(10);
             Assert.Throws<ArgumentOutOfRangeException>(() => ft.Sum(i));
         }
 
@@ -92,7 +92,7 @@ namespace Algorithm.Tests
         [TestCase(1, 0)]
         public void ArgumentOutOfRangeInSumTest2(int l, int r)
         {
-            var ft = new FenwickTree(10);
+            var ft = new FenwickTree<long>(10);
             Assert.Throws<ArgumentOutOfRangeException>(() => ft.Sum(l, r));
         }
 
@@ -100,7 +100,7 @@ namespace Algorithm.Tests
         [Test]
         public void BoundTest()
         {
-            var ft = new FenwickTree(10);
+            var ft = new FenwickTree<long>(10);
             ft.Add(3, long.MaxValue);
             ft.Add(5, long.MinValue);
             Assert.That(ft.Sum(0, 10), Is.EqualTo(-1));


### PR DESCRIPTION
- Update to .NET7.
- Update the package dependencies.
- Update `ModuloInteger` to use Generic Math interfaces.
- Update `FenwickTree` and `FenwickTree2D` to use Generic Math interfaces not restricted to `long` type.